### PR TITLE
[add] a new command (sw or switch) which switches the left and right pane

### DIFF
--- a/cmd/gomd/commands.go
+++ b/cmd/gomd/commands.go
@@ -137,6 +137,13 @@ func (a * app) cmdSync() error {
 func (a * app) cmdSwitch() error {
 	leftPath := a.left.Folder.Path
 	rightPath := a.right.Folder.Path
-	a.left.Folder.SetDir(rightPath)
-	return a.right.Folder.SetDir(leftPath)
+	err1 := a.left.Folder.SetDir(rightPath)
+	if(err1 != nil){
+		return err1
+	}
+	err2 := a.right.Folder.SetDir(leftPath)
+	if err2 != nil{
+		return err2
+	} 
+	return nil	
 }

--- a/cmd/gomd/commands.go
+++ b/cmd/gomd/commands.go
@@ -20,6 +20,8 @@ var implementedCommands = []string{
 	"q",
 	"quit",
 	"sync",
+	"sw",
+	"switch",
 }
 
 func (a *app) cmdAutocomplete(currentText string) (entries []string) {
@@ -58,6 +60,10 @@ func (a *app) executeCommand(command string) {
 		}
 	case "sync":
 		if err := a.cmdSync(); err != nil {
+			fmt.Fprintln(a.appOut, "error: ", err)
+		}
+	case "sw", "switch":
+		if err := a.cmdSwitch(); err != nil {
 			fmt.Fprintln(a.appOut, "error: ", err)
 		}
 	case "quit", "q":
@@ -126,4 +132,11 @@ func (a *app) cmdMkdir() error {
 
 func (a * app) cmdSync() error {
 	return a.right.Folder.SetDir(a.left.Folder.Path)
+}
+
+func (a * app) cmdSwitch() error {
+	leftPath := a.left.Folder.Path
+	rightPath := a.right.Folder.Path
+	a.left.Folder.SetDir(rightPath)
+	return a.right.Folder.SetDir(leftPath)
 }

--- a/cmd/gomd/commands.go
+++ b/cmd/gomd/commands.go
@@ -137,13 +137,9 @@ func (a * app) cmdSync() error {
 func (a * app) cmdSwitch() error {
 	leftPath := a.left.Folder.Path
 	rightPath := a.right.Folder.Path
-	err1 := a.left.Folder.SetDir(rightPath)
-	if(err1 != nil){
-		return err1
+	err := a.left.Folder.SetDir(rightPath)
+	if(err != nil){
+		return err
 	}
-	err2 := a.right.Folder.SetDir(leftPath)
-	if err2 != nil{
-		return err2
-	} 
-	return nil	
+	return a.right.Folder.SetDir(leftPath)	
 }


### PR DESCRIPTION
This PR fixes issue #14 

With the command `switch` or `sw`, the left and the right directory pane can be switched.